### PR TITLE
Use context data for logging in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ class UserObserver
      */
     public function hasOneCreating(User $user, Model $related)
     {
-        Log::info("Creating profile for user {$related->name}.");
+        Log::info("Creating profile for user.", ['user' => $related->name]);
     }
 
     /**
@@ -159,7 +159,7 @@ class UserObserver
      */
     public function hasOneCreated(User $user, Model $related)
     {
-        Log::info("Profile for user {$related->name} has been created.");
+        Log::info("Profile has been created.", ['user' => $related->name]);
     }
 }
 ```


### PR DESCRIPTION
Super pedantic change, I know. But I think it's better to use the best practices for logging in the examples, even if they're in a completely unrelated repo 😄 