### PR TITLE
feat: fetch relationship observables recursively

### DIFF
--- a/src/Traits/HasRelationshipObservables.php
+++ b/src/Traits/HasRelationshipObservables.php
@@ -27,7 +27,7 @@ trait HasRelationshipObservables
     public static function bootHasRelationshipObservables()
     {
         $methods = collect(
-            class_uses(static::class)
+            self::class_uses_deep(static::class)
         )->filter(function ($trait) {
             return Str::startsWith($trait, 'Chelout\RelationshipEvents\Concerns');
         })->flatMap(function ($trait) {
@@ -42,6 +42,17 @@ trait HasRelationshipObservables
         })->toArray();
 
         static::mergeRelationshipObservables($methods);
+    }
+
+    private static function class_uses_deep($class, $autoload = true) {
+        $traits = [];
+        do {
+            $traits = array_merge(class_uses($class, $autoload), $traits);
+        } while($class = get_parent_class($class));
+        foreach ($traits as $trait => $same) {
+            $traits = array_merge(class_uses($trait, $autoload), $traits);
+        }
+        return array_unique($traits);
     }
 
     /**


### PR DESCRIPTION
With this feature it is possible to use the traits also in base models and all inheritances will be tracked automatically. The source code for this change is actually from https://www.php.net/manual/de/function.class-uses.php